### PR TITLE
Added np.ndarray functionality & removed the input "stratify."

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,8 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 
 ##### Parameters
 
-    X,y,data: (pd.DataFrame/pd.Series)
-        data input for the split in pandas.DataFrame/pandas.Series format.
-    stratify (pd.Series): 
-        target variable for the split in pandas/eries format.
+    X,y,data: (pd.DataFrame/np.ndarray)
+        Data input for the split in pandas.DataFrame/np.ndarray format.
     test_size (float, optional):
         test split ratio. Default = 0.3
     train_size (float, optional):
@@ -157,8 +155,7 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 ```Python
   from verstack.stratified_continuous_split import scsplit
   
-  train, test = scsplit(data, stratify = data['continuous_column_name'])
-  X_train, X_val, y_train, y_val = scsplit(X, y, stratify = y, 
+  X_train, X_val, y_train, y_val = scsplit(X, y, 
                                            test_size = 0.3, random_state = 5)
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 
 ##### Parameters
 
-    X,y,data: (pd.DataFrame/np.ndarray)
+    X,y,data: (pd.DataFrame/pd.Series/np.ndarray)
         Data input for the split in pandas.DataFrame/np.ndarray format.
+    stratify (pd.Series): 
+        target variable for the split in pandas/eries format.
     test_size (float, optional):
         test split ratio. Default = 0.3
     train_size (float, optional):
@@ -151,7 +153,16 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
         Default = 5
 
 ##### Examples
+_Pandas dataframe_
+```Python
+  from verstack.stratified_continuous_split import scsplit
   
+  train, test = scsplit(data, stratify = data['continuous_column_name'])
+  X_train, X_val, y_train, y_val = scsplit(X, y, stratify = y, 
+                                           test_size = 0.3, random_state = 5)
+```
+
+_numpy arrays_
 ```Python
   from verstack.stratified_continuous_split import scsplit
   


### PR DESCRIPTION
## Outline of changes:
There are two changes that I have made.
1. I have altered the functions `estimate_nbins()` and `scsplit()` to be able to take both pandas dataframes and numpy arrays as inputs.

2. I have removed the input "stratify" from `scsplit()` and, additionally, have made the inputs "X" and "y" required. The reason I have done this is to make the function behave more like scikit-learn's `train_test_split(X, y)`. I believe that this should provide a more seamless integration of the function into other people's projects. 

Additionally, I have updated the readme to account for my changes. However, I have not changed the version info.