### PR TITLE
Reverted the stratify input while maintaining numpy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,8 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 
 ##### Parameters
 
-    X,y,data: (pd.DataFrame/pd.Series)
-        data input for the split in pandas.DataFrame/pandas.Series format.
-    stratify (pd.Series): 
-        target variable for the split in pandas/eries format.
+    X,y,data: (pd.DataFrame/np.ndarray)
+        Data input for the split in pandas.DataFrame/np.ndarray format.
     test_size (float, optional):
         test split ratio. Default = 0.3
     train_size (float, optional):
@@ -157,8 +155,7 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 ```Python
   from verstack.stratified_continuous_split import scsplit
   
-  train, test = scsplit(data, stratify = data['continuous_column_name'])
-  X_train, X_val, y_train, y_val = scsplit(X, y, stratify = y, 
+  X_train, X_val, y_train, y_val = scsplit(X, y, 
                                            test_size = 0.3, random_state = 5)
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
 
 ##### Parameters
 
-    X,y,data: (pd.DataFrame/np.ndarray)
+    X,y,data: (pd.DataFrame/pd.Series/np.ndarray)
         Data input for the split in pandas.DataFrame/np.ndarray format.
+    stratify (pd.Series): 
+        target variable for the split in pandas/eries format.
     test_size (float, optional):
         test split ratio. Default = 0.3
     train_size (float, optional):
@@ -151,7 +153,16 @@ Can accept only pandas.DataFrame/pandas.Series as data input.
         Default = 5
 
 ##### Examples
+_Pandas dataframe_
+```Python
+  from verstack.stratified_continuous_split import scsplit
   
+  train, test = scsplit(data, stratify = data['continuous_column_name'])
+  X_train, X_val, y_train, y_val = scsplit(X, y, stratify = y, 
+                                           test_size = 0.3, random_state = 5)
+```
+
+_numpy arrays_
 ```Python
   from verstack.stratified_continuous_split import scsplit
   


### PR DESCRIPTION
## Outline of changes:
I have kept my inital alterations to the function `estimate_nbins().` Additionally, I have reverted and adjusted the funtion `scsplit()` to be able to take both pandas dataframes and numpy arrays as inputs while still maintaining the `stratify` input option. However, I have changed `stratify` to be an optional input rather than a required one. This is because if you pass both `X` and `y` as dataframes, I feel that there is no need to specify `y` again as the stratifyer.

