### PR TITLE
raise meaningful exception on wrong return type

### DIFF
--- a/verstack/Multicore.py
+++ b/verstack/Multicore.py
@@ -185,6 +185,6 @@ class Multicore():
                     result.update(dictionary)
             else:
                 raise TypeError(f"Invalid return type for function '{func.__name__}'."
-			" Only list, dict, Numpy ndarray and Panda's Series are supported!")
+                        " Only list, dict, Numpy ndarray and Panda's Series are supported!")
             return result
 

--- a/verstack/Multicore.py
+++ b/verstack/Multicore.py
@@ -183,5 +183,8 @@ class Multicore():
                 result = {}
                 for dictionary in data_from_results:
                     result.update(dictionary)
+            else:
+                raise TypeError(f"Invalid return type for function '{func.__name__}'."
+			" Only list, dict, Numpy ndarray and Panda's Series are supported!")
             return result
 


### PR DESCRIPTION
Using incomplete 'if' branches is not a good practice. 
Users may be confused by the error message in the library if the return type of their parallel function is not supported ie. other type of iterable or container. 

Meaningful warning included.
